### PR TITLE
Port app-click to use musl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+UK_ROOT ?= $(PWD)/.unikraft/unikraft
+UK_LIBS ?= $(PWD)/.unikraft/libs
+LIBS := $(UK_LIBS)/musl:$(UK_LIBS)/lwip:$(UK_LIBS)/click
+
+all:
+	@$(MAKE) -C $(UK_ROOT) A=$(PWD) L=$(LIBS)
+
+$(MAKECMDGOALS):
+	@$(MAKE) -C $(UK_ROOT) A=$(PWD) L=$(LIBS) $(MAKECMDGOALS)

--- a/Makefile.uk
+++ b/Makefile.uk
@@ -1,0 +1,1 @@
+$(eval $(call addlib,appclick))

--- a/kraft.yaml
+++ b/kraft.yaml
@@ -13,7 +13,7 @@ libraries:
     kconfig:
       - CONFIG_LWIP=y
       - CONFIG_LWIP_AUTOIFACE=n
-  newlib:
+  musl:
     version: '0.5'
   click:
     version: '0.5'


### PR DESCRIPTION
Supposed to address this issue:  #https://github.com/unikraft/app-click/issues/3

Tried to test its correctness by cloning the [Unikraft](https://github.com/unikraft/unikraft) repository under .unikraft/unikraft and the dependencies ([lib-lwip](https://github.com/unikraft/lib-lwip), [lib-musl](https://github.com/unikraft/lib-musl), [lib-click](https://github.com/unikraft/lib-click)) under .unikraft/libs and then properly setting them up with `make menuconfig` from the base folder.

Unfortunately after configuration there is a loop that pops up during `make` or `make prepare`:
> which: no time in (/home/mekal/anaconda3/condabin:/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/lib/jvm/default/bin:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl:/usr/lib/rustup/bin)
>   CP      config
>   ELEMMK  libclick: .elementsmk